### PR TITLE
feat: update @actions/core to v1.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@actions/core": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.4.tgz",
-      "integrity": "sha512-YJCEq8BE3CdN8+7HPZ/4DxJjk/OkZV2FFIf+DlZTC/4iBlzYCD5yjRR6eiOS5llO11zbRltIRuKAjMKaWTE6cg=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
     },
     "@babel/cli": {
       "version": "7.8.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "private": true,
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "^1.2.4",
+    "@actions/core": "^1.2.6",
     "@babel/runtime": "^7.9.6",
     "semantic-release": "^17.0.7"
   },


### PR DESCRIPTION
Bumping version of package to support of exportVariable and addPath for environment variables

### Related Issue

<!-- Please link to the github issue here. -->

https://github.com/codfish/semantic-release-action/issues/**NUMBER**

### Description

With the v1, we started seeing following issue on the semantic-release actions:
![image](https://user-images.githubusercontent.com/11468095/99295816-7fdeef00-280b-11eb-9b17-9716e599e08c.png)

As per the document provided by github: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/, updating the version of `@actions/core` package
<!-- Brief description of the code changes. Add supporting screenshots & videos where applicable. -->

### Checklist

<!-- Go over the checklist, and put an `x` in all the boxes when you confirm they've been done. -->

- [ ] I have reviewed the code changes myself
- [ ] My code meets all of the acceptance criteria of the ticket it closes.
- [ ] I have made all necessary changes to the documentation.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] Any dependent changes have been merged and published.
