### PR TITLE
chore: bump node to v18.17 becasue of semantic-release v22 requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.7.0
+FROM node:18.17
 
 # nice clean home for our action files
 RUN mkdir /action


### PR DESCRIPTION
### Related Issue

see https://github.com/semantic-release/semantic-release/releases/tag/v22.0.0

### Description

