### PR TITLE
Force install additional deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18.17
+FROM node:18.7.0
 
 # nice clean home for our action files
 RUN mkdir /action

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -22,9 +22,13 @@ const installPackages = (packages) => {
   try {
     const packagesArr = arrify(packages);
     core.debug(`Installing additional packages: ${packagesArr}`);
-    const spawn = childProcess.spawnSync('npm', ['install', '--no-save', ...packagesArr], {
-      stdio: ['inherit', 'inherit', 'pipe'],
-    });
+    const spawn = childProcess.spawnSync(
+      'npm',
+      ['install', '--no-save', '--no-audit', '--no-fund', '--force', ...packagesArr],
+      {
+        stdio: ['inherit', 'inherit', 'pipe'],
+      },
+    );
     if (spawn.status !== 0) {
       throw new Error(spawn.stderr);
     }


### PR DESCRIPTION
node 18.17 has a newer version of git causing ownership issues:

![image](https://github.com/codfish/semantic-release-action/assets/1666298/e0a8e97f-064b-4183-a5c6-816bcae76856)

This will get fixed in a follow up but for now v2 of this action will continue using 18.7 w/ semantic release version 20