### PR TITLE
Container size reduction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:20.11.0
+FROM node:20.11.0-alpine
+
+RUN apk add --no-cache git
 
 # nice clean home for our action files
 RUN mkdir /action


### PR DESCRIPTION
### Related Issue

<!-- Please link to the github issue here. -->

https://github.com/codfish/semantic-release-action/issues/202

### Description

This changes the Dockerfile to reduce the built container size to 297MB - reducing the pull time significantly. This also leads to less layers and hopefully less compression which was one of the major slowdowns for extracting after download.
