### PR TITLE
fix: update release workflow to ensure every docker tag is pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,28 +62,31 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: docker login
+      - name: Docker login
         run: |
           echo "$GCR_TOKEN" | docker login ghcr.io -u codfish --password-stdin
         env:
           GCR_TOKEN: ${{ secrets.GCR_TOKEN }}
 
+      # Step to create a list of tags to push to GCR always including the latest tag and optionally
+      # the new release tag and major release tag.
+      - name: Create tags list
+        id: tags
+        shell: bash
+        run: |
+          TAGS="ghcr.io/codfish/semantic-release-action:latest"
+          if [ "${{ steps.semantic.outputs.new-release-published }}" == "true" ]; then
+            TAGS="${TAGS},ghcr.io/codfish/semantic-release-action:v${{ steps.semantic.outputs.release-version }}"
+            TAGS="${TAGS},ghcr.io/codfish/semantic-release-action:v${{ steps.semantic.outputs.release-major }}"
+          fi
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
+      # Push docker images to GCR
       # Dockerhub is auto synced with the repo, no need to explicitly deploy
-      - name: build and push latest docker image to GCR
+      - name: Build and push docker images to GCR
         uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/arm64,linux/amd64
           push: true
-          tags: ghcr.io/codfish/semantic-release-action:latest
-
-      - name: push docker images for releases to GCR
-        if: steps.semantic.outputs.new-release-published == 'true'
-        run: |
-          docker tag ghcr.io/codfish/semantic-release-action ghcr.io/codfish/semantic-release-action:$VERSION_TAG
-          docker tag ghcr.io/codfish/semantic-release-action ghcr.io/codfish/semantic-release-action:$MAJOR_TAG
-          docker push ghcr.io/codfish/semantic-release-action:$VERSION_TAG
-          docker push ghcr.io/codfish/semantic-release-action:$MAJOR_TAG
-        env:
-          VERSION_TAG: v${{ steps.semantic.outputs.release-version }}
-          MAJOR_TAG: v${{ steps.semantic.outputs.release-major }}
+          tags: ${{ steps.tags.outputs.tags }}


### PR DESCRIPTION
### Related Issue

<!-- Please link to the github issue here. -->

Follow up to https://github.com/codfish/semantic-release-action/pull/207

### Description

Fix release workflow, don't push versioned images separately, just infer all tags in a prior step and pass them to a single step using the `docker/build-push-action` action.

![image](https://github.com/codfish/semantic-release-action/assets/1666298/a3b10d24-9f5f-4915-b776-5fb1b6073645)


https://github.com/codfish/semantic-release-action/pull/207#issuecomment-2171815892
