### PR TITLE
feat: add working-directory input

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -39,6 +39,7 @@ jobs:
           repository-url: https://github.com/codfish/semantic-release-action.git
           extends: '@semantic-release/apm-config'
           tag-format: 'ver${version}'
+          working-directory: .
           additional-packages: |
             ['@semantic-release/apm', '@semantic-release/git']
           plugins: |

--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ defined in your repo (`.releaserc`, `release.config.js`, `release` prop in `pack
 | `extends`             | `Array`, `String`           | List of modules or file paths containing a shareable configuration.                                                                                                                                                                                             | [Semantic default](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#extends)                      |
 | `additional-packages` | `Array`, `String`           | Define a list of additional plugins/configurations (official or community) to install. Use this if you 1) use any plugins other than the defaults, which are already installed along with semantic-release or 2) want to extend from a shareable configuration. | `[]`                                                                                                                                          |
 | `dry-run`             | `Boolean`                   | The objective of the dry-run mode is to get a preview of the pending release. Dry-run mode skips the following steps: prepare, publish, success and fail.                                                                                                       | [Semantic default](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#dryrun)                       |
+| `working-directory`   | `String`                    | The working directory to use for all semantic-release actions.                                                                                                                                                                                                  | `.`                                                                                                                                           |
 | `repository-url`      | `String`                    | The git repository URL                                                                                                                                                                                                                                          | [Semantic default](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#repositoryurl)                |
 | `tag-format`          | `String`                    | The Git tag format used by semantic-release to identify releases.                                                                                                                                                                                               | [Semantic default](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#tagformat)                    |
 
@@ -266,6 +267,7 @@ steps:
         ]
       repository-url: https://github.com/codfish/semantic-release-action.git
       tag-format: 'v${version}'
+      working-directory: dist
       extends: '@semantic-release/apm-config'
       additional-packages: |
         ['@semantic-release/apm@4.0.0', '@semantic-release/git']

--- a/action.yml
+++ b/action.yml
@@ -48,8 +48,7 @@ inputs:
       https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#tagformat'
     required: false
   working-directory:
-    description:
-      'The working directory to use for all semantic-release actions.'
+    description: 'The working directory to use for all semantic-release actions.'
     required: false
   branch:
     description:

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,10 @@ inputs:
       'The Git tag format used by semantic-release to identify releases.
       https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#tagformat'
     required: false
+  working-directory:
+    description:
+      'The working directory to use for all semantic-release actions.'
+    required: false
   branch:
     description:
       'DEPRECATED. Will continue to be supported for v1. Use `branches` instead. Previously used in
@@ -88,4 +92,5 @@ runs:
     - ${{ inputs.dry-run }}
     - ${{ inputs.repository-url }}
     - ${{ inputs.tag-format }}
+    - ${{ inputs.working-directory }}
     - ${{ inputs.branch }}

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -74,8 +74,9 @@ const setGitConfigSafeDirectory = () => {
  * @see https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#options
  */
 async function run() {
+  const workingDirectory = parseInput(core.getInput('working-directory', { required: false })) || '.';
   const configFile = await cosmiconfig('release')
-    .search()
+    .search(workingDirectory)
     .then((result) => result?.config);
   const branch = parseInput(core.getInput('branch', { required: false }));
   // Branches are parsed in this order:
@@ -112,6 +113,7 @@ async function run() {
   core.debug(`dry-run input: ${dryRun}`);
   core.debug(`repository-url input: ${repositoryUrl}`);
   core.debug(`tag-format input: ${tagFormat}`);
+  core.debug(`working-directory input: ${workingDirectory}`);
 
   setGitConfigSafeDirectory();
 
@@ -143,7 +145,7 @@ async function run() {
 
   core.debug(`options after cleanup: ${JSON.stringify(options)}`);
 
-  const result = await semanticRelease(options);
+  const result = await semanticRelease(options, { cwd: workingDirectory });
   if (!result) {
     core.debug('No release published');
 

--- a/entrypoint.js
+++ b/entrypoint.js
@@ -74,7 +74,8 @@ const setGitConfigSafeDirectory = () => {
  * @see https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#options
  */
 async function run() {
-  const workingDirectory = parseInput(core.getInput('working-directory', { required: false })) || '.';
+  const workingDirectory =
+    parseInput(core.getInput('working-directory', { required: false })) || '.';
   const configFile = await cosmiconfig('release')
     .search(workingDirectory)
     .then((result) => result?.config);


### PR DESCRIPTION
### Related Issue

#209

### Description

Adds `working-directory` input which affects how it discovers release config as well as the CWD it passes in to the semantic-release command.
